### PR TITLE
Fix algo/detect/assigner.py assigner_feat_for_aids test

### DIFF
--- a/wbia/algo/detect/assigner.py
+++ b/wbia/algo/detect/assigner.py
@@ -427,8 +427,8 @@ def assigner_feat_for_aids(ibs, aid_list, default_species_conf='wild_dog'):
         >>> from wbia.algo.detect.train_assigner import *
         >>> ibs = assigner_testdb_ibs()
         >>> aids = ibs.get_valid_aids()
-        >>> result = assigner_feat_for_aids(aids)
-        >>> 'assigner_viewpoint_features'
+        >>> assigner_feat_for_aids(ibs, aids)
+        'assigner_viewpoint_features'
     """
     species = _get_assigner_species_for_aids(ibs, aid_list, default_species_conf)
     feature_col = SPECIES_CONFIG_MAP[species]['annot_feature_col']


### PR DESCRIPTION
```
DOCTEST TRACEBACK
Traceback (most recent call last):

  File "/virtualenv/env3/lib/python3.7/site-packages/xdoctest/doctest_example.py", line 598, in run
    exec(code, test_globals)

  File "<doctest:/wbia/wildbook-ia/wbia/algo/detect/assigner.py::assigner_feat_for_aids:0>", line rel: 7, abs: 430, in <module>
    >>> result = assigner_feat_for_aids(aids)

TypeError: assigner_feat_for_aids() missing 1 required positional argument: 'aid_list'
DOCTEST REPRODUCTION
CommandLine:
    pytest /wbia/wildbook-ia/wbia/algo/detect/assigner.py::assigner_feat_for_aids:0
/wbia/wildbook-ia/wbia/algo/detect/assigner.py:430: TypeError
```