### PR TITLE
Update container to include wait-for to wait on database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN set -x \
        libgl1 \
        #: required to stop prompting by pgloader
        libssl1.0.0 \
+       #: required by wait-for
+       netcat \
        #: sqlite->postgres dependency
        pgloader \
        #: dev debug dependency
@@ -79,6 +81,7 @@ RUN set -x \
        python3-setuptools \
        python3-venv \
        unzip \
+       wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Install CNMeM, a memory manager for CUDA
@@ -94,6 +97,11 @@ RUN set -x \
     && mkdir -p /data \
     && chown wbia:wbia /data \
     && chmod 755 /data
+
+# Install wait-for
+RUN set -x \
+    && wget -o /usr/local/bin/wait-for https://raw.githubusercontent.com/eficode/wait-for/master/wait-for \
+    && chmod a+x /usr/local/bin/wait-for
 
 # ###
 # Application setup


### PR DESCRIPTION
This enables the container to wait for the database to receive
connections before starting the application.

Note, this does have some overlap with the docker-compose `depends_on`.
But also keep in mind that `depends_on` is not honored in docker swarm mode.
See also, https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on

Intended usage is something like `wait-for db:5432 -- my-app start`

