### PR TITLE
Update container to include wait-for to wait on database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN set -x \
     && apt-get install -y --no-install-recommends \
        # ** Please sort alphabetically **
        ca-certificates \
+       #: required for downloading 'wait-for'
+       curl \
        #: used during package acquisition
        git \
        #: tool to setuid+setgid+setgroups+exec at execution time
@@ -69,6 +71,8 @@ RUN set -x \
        libgl1 \
        #: required to stop prompting by pgloader
        libssl1.0.0 \
+       #: required by wait-for
+       netcat \
        #: sqlite->postgres dependency
        pgloader \
        #: dev debug dependency
@@ -94,6 +98,13 @@ RUN set -x \
     && mkdir -p /data \
     && chown wbia:wbia /data \
     && chmod 755 /data
+
+# Install wait-for
+RUN set -x \
+    && curl -s https://raw.githubusercontent.com/eficode/wait-for/v2.0.0/wait-for > /usr/local/bin/wait-for \
+    && chmod a+x /usr/local/bin/wait-for \
+    # test it works
+    && wait-for google.com:80 -- echo "success"
 
 # ###
 # Application setup


### PR DESCRIPTION
This enables the container to wait for the database to receive
connections before starting the application.

Note, this does have some overlap with the docker-compose depends_on.
But also keep in mind that depends_on is not honored in docker swarm mode.
See also, https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on

Intended usage is something like `wait-for db:5432 -- my-app start`