### PR TITLE
Reassign ownership of the dbdir on start up

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -13,8 +13,11 @@ if [ -d /code ]; then
 fi
 
 
-echo "*** $0 --- progressing to main execution"
+echo "*** $0 --- Assigning data directory ownership and permissions"
+chown -R wbia:wbia ${WBIA_DB_DIR}
 
+
+echo "*** $0 --- progressing to main execution"
 # Supply EXEC_PRIVILEGED=1 to run your given command as the privileged user.
 if [ $EXEC_PRIVILEGED ]; then
     exec "$@"


### PR DESCRIPTION
This ensures container's runtime user has access to read and write to
the database directory.

Ran into this usecase within compose when assigning a named volume.

```
services:
  wbia:
    image: wildme/wildbook-ia:latest
    ...
    volumes:
      - wbia-var:/data/db
volumes:
  wbia-var:
```