### PR TITLE
Revert changes to devops/publish.sh, broke github packages

### DIFF
--- a/devops/publish.sh
+++ b/devops/publish.sh
@@ -18,14 +18,19 @@ shift $((OPTIND - 1))
 
 # Assign variables
 TAG=${TAG:-latest}
-REGISTRY=${REGISTRY:-wildme}
+REGISTRY=${REGISTRY:-}
 IMAGES=${@:-wbia-base wbia-dependencies wbia-provision wbia wildbook-ia}
+# Set the image prefix
+if [ -n "$REGISTRY" ]; then
+    IMG_PREFIX="${REGISTRY}/wildmeorg/wildbook-ia/"
+else
+    IMG_PREFIX="wildme/"
+fi
 
 # Tag built images from `build.sh`, which tags as `latest`
 for IMG in $IMAGES; do
-    IMG_TAG="${REGISTRY}/${IMG}:${TAG}"
-    echo "Tagging wildme/${IMG}:latest --> ${IMG_TAG}"
-    docker tag wildme/${IMG}:latest ${IMG_TAG}
-    echo "Pushing ${IMG_TAG}"
-    docker push ${IMG_TAG}
+    echo "Tagging wildme/${IMG}:latest --> ${IMG_PREFIX}${IMG}:${TAG}"
+    docker tag wildme/${IMG}:latest ${IMG_PREFIX}${IMG}:${TAG}
+    echo "Pushing ${IMG_PREFIX}${IMG}:${TAG}"
+    docker push ${IMG_PREFIX}${IMG}:${TAG}
 done


### PR DESCRIPTION
When running the nightly workflow, "Push to GitHub Packages" step:

```
bash devops/publish.sh -t nightly -r docker.pkg.github.com wildbook-ia
...
error parsing HTTP 404 response body: invalid character 'p' after top-level value: "404 page not found\n"
```

This is because instead of tagging the image as
`docker.pkg.github.com/wildmeorg/wildbook-ia/<img>:latest`, the image
was tagged as `docker.pkg.github.com/<img>:latest`, which causes github
packages to return the 404 error.

The commits partially reverted are bbd35a8 and 431e8927.