### PR TITLE
Add /api/version/ to return wbia version

### DIFF
--- a/wbia/control/manual_meta_funcs.py
+++ b/wbia/control/manual_meta_funcs.py
@@ -933,6 +933,20 @@ def get_metadata_rowid_from_metadata_key(ibs, metadata_key_list, db):
     return metadata_rowid_list
 
 
+@register_api('/api/version/', methods=['GET'])
+def get_version(ibs):
+    r"""
+    Returns the version of wbia
+
+    RESTful
+        Method: GET
+        URL:    /api/version/
+    """
+    from wbia._version import __version__
+
+    return {'version': __version__}
+
+
 @register_api('/api/core/version/', methods=['GET'])
 def get_database_version_alias(ibs, db=None):
     r"""

--- a/wbia/tests/control/test_manual_meta_funcs.py
+++ b/wbia/tests/control/test_manual_meta_funcs.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+import wbia
+from wbia._version import __version__
+
+
+def test_version():
+    with wbia.opendb_with_web('testdb2') as (ibs, client):
+        resp = client.get('/api/version/')
+        assert resp.status_code == 200
+        assert resp.content_type == 'application/json; charset=utf-8'
+        assert resp.json['response'] == {'version': __version__}


### PR DESCRIPTION
```
GET /api/version/
```

should return something like:

```
{
  "status": {
    "success": true,
    "code": 200,
    "message": "",
    "cache": -1
  },
  "response": {
    "version": "3.5.1.dev23"
  }
}
```