### PR TITLE
Fix uri_.strip and urls with ports in parse_imageinfo and localize_image

### DIFF
--- a/wbia/algo/preproc/preproc_image.py
+++ b/wbia/algo/preproc/preproc_image.py
@@ -116,7 +116,7 @@ def parse_imageinfo(gpath):
                         ), '200 code not received on download'
                     except Exception:
                         scheme = urlsplit(uri_, allow_fragments=False).scheme
-                        uri_ = uri_.strip('%s://' % (scheme,))
+                        uri_ = uri_[len('%s://' % (scheme,)) :]
                         uri_path = urlquote(uri_.encode('utf8'))
                         uri_ = '%s://%s' % (scheme, uri_path)
                         response = requests.get(uri_, stream=True, allow_redirects=True)

--- a/wbia/algo/preproc/preproc_image.py
+++ b/wbia/algo/preproc/preproc_image.py
@@ -115,10 +115,12 @@ def parse_imageinfo(gpath):
                             response.status_code == 200
                         ), '200 code not received on download'
                     except Exception:
-                        scheme = urlsplit(uri_, allow_fragments=False).scheme
-                        uri_ = uri_[len('%s://' % (scheme,)) :]
-                        uri_path = urlquote(uri_.encode('utf8'))
-                        uri_ = '%s://%s' % (scheme, uri_path)
+                        parts = urlsplit(uri_, allow_fragments=False)
+                        uri_ = uri_[len('%s://' % (parts.scheme,)) :]
+                        hostname = urlquote(parts.hostname.encode('utf8'))
+                        if parts.port:
+                            hostname = f'{hostname}:{parts.port}'
+                        uri_ = '%s://%s%s' % (parts.scheme, hostname, parts.path)
                         response = requests.get(uri_, stream=True, allow_redirects=True)
                         assert (
                             response.status_code == 200

--- a/wbia/control/manual_image_funcs.py
+++ b/wbia/control/manual_image_funcs.py
@@ -594,7 +594,7 @@ def localize_images(ibs, gid_list_=None):
                     ), '200 code not received on download'
                 except Exception:
                     scheme = urlsplit(uri_, allow_fragments=False).scheme
-                    uri_ = uri_.strip('%s://' % (scheme,))
+                    uri_ = uri_[len('%s://' % (scheme,)) :]
                     uri_path = urlquote(uri_.encode('utf8'))
                     uri_ = '%s://%s' % (scheme, uri_path)
                     response = requests.get(uri_, stream=True, allow_redirects=True)

--- a/wbia/control/manual_image_funcs.py
+++ b/wbia/control/manual_image_funcs.py
@@ -117,7 +117,7 @@ def get_valid_gids(
     require_unixtime=False,
     require_gps=None,
     reviewed=None,
-    **kwargs
+    **kwargs,
 ):
     r"""
     Args:
@@ -317,7 +317,7 @@ def add_images(
     ensure_unique=False,
     ensure_loadable=True,
     ensure_exif=True,
-    **kwargs
+    **kwargs,
 ):
     r"""
     Adds a list of image paths to the database.
@@ -593,10 +593,12 @@ def localize_images(ibs, gid_list_=None):
                         response.status_code == 200
                     ), '200 code not received on download'
                 except Exception:
-                    scheme = urlsplit(uri_, allow_fragments=False).scheme
-                    uri_ = uri_[len('%s://' % (scheme,)) :]
-                    uri_path = urlquote(uri_.encode('utf8'))
-                    uri_ = '%s://%s' % (scheme, uri_path)
+                    parts = urlsplit(uri_, allow_fragments=False)
+                    uri_ = uri_[len('%s://' % (parts.scheme,)) :]
+                    hostname = urlquote(parts.hostname.encode('utf8'))
+                    if parts.port:
+                        hostname = f'{hostname}:{parts.port}'
+                    uri_ = '%s://%s%s' % (parts.scheme, hostname, parts.path)
                     response = requests.get(uri_, stream=True, allow_redirects=True)
                     assert (
                         response.status_code == 200

--- a/wbia/tests/control/test_manual_image_funcs.py
+++ b/wbia/tests/control/test_manual_image_funcs.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+import pathlib
+import tempfile
+from unittest import mock
+import uuid
+
+
+IMAGE_UUIDS = [
+    uuid.UUID('784817e0-ca90-425d-8a81-edccfe3e538b'),
+    uuid.UUID('8f0dba1e-534f-43a1-8bf2-78f80b20427d'),
+]
+IMAGE_URIS = [
+    f'http://houston/api/v1/assets/src/{image_uuid}' for image_uuid in IMAGE_UUIDS
+]
+
+
+def test_add_images_uris():
+    from wbia.control.manual_image_funcs import add_images, _compute_image_uuids
+
+    ibs = mock.Mock()
+    ibs.cfg.other_cfg.auto_localize = False
+    ibs.get_image_paths.return_value = IMAGE_URIS
+    ibs._compute_image_uuids.side_effect = lambda *args, **kwargs: _compute_image_uuids(
+        ibs, *args, **kwargs
+    )
+    ibs.db.add_cleanly.return_value = [1, 2]
+    ibs.check_image_loadable.return_value = [], []
+
+    response = mock.Mock(status_code=200)
+    with open('wbia/web/static/images/logo-wildme.png', 'rb') as f:
+        response.iter_content.return_value = [f.read()]
+
+    def _get(*args, **kwargs):
+        if get.call_count == 1:
+            return mock.Mock(status_code=500)
+        return response
+
+    with mock.patch('requests.get', side_effect=_get) as get:
+        result_ids = add_images(ibs, IMAGE_URIS)
+
+    assert result_ids == [1, 2]
+    assert get.call_args_list == [
+        mock.call(IMAGE_URIS[0], allow_redirects=True, stream=True),
+        mock.call(IMAGE_URIS[0], allow_redirects=True, stream=True),
+        mock.call(IMAGE_URIS[1], allow_redirects=True, stream=True),
+    ]
+    assert not ibs.localize_images.called
+
+
+def test_add_images_auto_localized():
+    from wbia.control.manual_image_funcs import add_images, _compute_image_uuids
+
+    ibs = mock.Mock()
+    ibs.cfg.other_cfg.auto_localize = False
+    ibs.get_image_paths.return_value = [f'{image_uri}.png' for image_uri in IMAGE_URIS]
+    ibs._compute_image_uuids.side_effect = lambda *args, **kwargs: _compute_image_uuids(
+        ibs, *args, **kwargs
+    )
+    ibs.db.add_cleanly.return_value = [1, 2]
+    ibs.check_image_loadable.return_value = [], []
+
+    response = mock.Mock(status_code=200)
+    with open('wbia/web/static/images/logo-wildme.png', 'rb') as f:
+        response.iter_content.return_value = [f.read()]
+
+    def _get(*args, **kwargs):
+        if get.call_count == 1:
+            return mock.Mock(status_code=500)
+        return response
+
+    with mock.patch('requests.get', side_effect=_get) as get:
+        result_ids = add_images(ibs, IMAGE_URIS, auto_localize=True)
+
+    assert result_ids == [1, 2]
+    assert get.call_args_list == [
+        mock.call(IMAGE_URIS[0], allow_redirects=True, stream=True),
+        mock.call(IMAGE_URIS[0], allow_redirects=True, stream=True),
+        mock.call(IMAGE_URIS[1], allow_redirects=True, stream=True),
+    ]
+    assert ibs.localize_images.call_args_list == [mock.call([1, 2])]
+
+
+def test_localize_images(request):
+    from wbia.control.manual_image_funcs import localize_images
+
+    td = tempfile.TemporaryDirectory()
+    imgdir = pathlib.Path(td.name)
+    request.addfinalizer(td.cleanup)
+    ibs = mock.Mock(imgdir=str(imgdir))
+    ibs.get_image_uris.return_value = IMAGE_URIS
+    ibs.get_image_uuids.return_value = IMAGE_UUIDS
+    ibs.get_image_exts.return_value = ['.png', '.png']
+
+    response = mock.Mock(status_code=200)
+    with open('wbia/web/static/images/logo-wildme.png', 'rb') as f:
+        response.iter_content.return_value = [f.read()]
+
+    def _get(*args, **kwargs):
+        if get.call_count == 1:
+            return mock.Mock(status_code=500)
+        return response
+
+    with mock.patch(
+        'wbia.control.manual_image_funcs.ut.grab_s3_contents'
+    ) as grab_s3_contents:
+        with mock.patch('requests.get', side_effect=_get) as get:
+            localize_images(ibs, [1, 2])
+
+    assert get.call_args_list == [
+        mock.call(IMAGE_URIS[0], stream=True, allow_redirects=True),
+        mock.call(IMAGE_URIS[0], stream=True, allow_redirects=True),
+        mock.call(IMAGE_URIS[1], stream=True, allow_redirects=True),
+    ]
+    assert not grab_s3_contents.called
+    assert sorted(imgdir.glob('*')) == [
+        imgdir / f'{image_uuid}.png' for image_uuid in IMAGE_UUIDS
+    ]
+    for image_uuid in IMAGE_UUIDS:
+        with open('wbia/web/static/images/logo-wildme.png', 'rb') as f:
+            with (imgdir / f'{image_uuid}.png').open('rb') as g:
+                assert f.read() == g.read()
+    assert ibs.set_image_uris.call_args_list == [
+        mock.call([1, 2], [f'{image_uuid}.png' for image_uuid in IMAGE_UUIDS]),
+    ]


### PR DESCRIPTION
- Fix uri_.strip in parse_imageinfo and localize_image

  The original code looks like this:
  
  ```
  scheme = urlsplit(uri_, allow_fragments=False).scheme
  uri_ = uri_.strip('%s://' % (scheme,))
  ```
  
  If uri_ is `http://houston/api/v1/assets/`:
  
  ```
  >>> uri_.strip('http://')
  'ouston/api/v1/assets'
  ```
  
  it is stripping all `h`, `t`, `p`, `:` and `/` causing the leading `h` in
  `houston` and the trailing `/` to be stripped.
  
  Change the code to specifically remove the leading `http://` instead:
  
  ```
  scheme = urlsplit(uri_, allow_fragments=False).scheme
  uri_ = uri_[len('%s://' % (scheme,)) :]
  ```

- Fix urls with ports in parse_imageinfo and localize_image

  Urls with ports like `http://houston:5000` are quoted incorrectly in the
  exception handling part of `parse_imageinfo` and `localize_image` and
  become `http://houston%255000`, causing `requests` to connect to
  hostname `houston%255000` port `80` instead of to `houston` port `5000`.
  
  Fix this by only quoting the hostname and appending to port number
  afterwards:
  
  ```
  hostname = urlquote(parts.hostname.encode('utf8'))
  if parts.port:
      hostname = f'{hostname}:{parts.port}'
  ```
