### PR TITLE
Add support for houston urls and option to download images in /api/engine/detect/cnn/lightnet/

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -45,6 +45,7 @@ pyshp
 pyzmq>=14.7.0
 
 requests>=2.5.0
+requests-oauthlib
 scikit-image>=0.12.3
 scikit-learn>=0.24.0
 scipy>=0.18.0

--- a/wbia/algo/preproc/preproc_image.py
+++ b/wbia/algo/preproc/preproc_image.py
@@ -6,6 +6,7 @@ import warnings
 import vtool.exif as vtexif
 import utool as ut
 from vtool.exif import ORIENTATION_DICT_INVERSE, ORIENTATION_UNDEFINED, ORIENTATION_000
+from wbia.utils import call_houston
 
 
 EXIF_UNDEFINED = ORIENTATION_DICT_INVERSE[ORIENTATION_UNDEFINED]
@@ -73,7 +74,8 @@ def parse_imageinfo(gpath):
 
     url_protos = ['https://', 'http://']
     s3_proto = ['s3://']
-    valid_protos = s3_proto + url_protos
+    houston_proto = ['houston+']
+    valid_protos = s3_proto + url_protos + houston_proto
 
     def isproto(gpath, valid_protos):
         return any(gpath.startswith(proto) for proto in valid_protos)
@@ -127,6 +129,14 @@ def parse_imageinfo(gpath):
                         ), '200 code not received on download'
 
                     # Save
+                    with open(temp_filepath, 'wb') as temp_file_:
+                        for chunk in response.iter_content(1024):
+                            temp_file_.write(chunk)
+                elif isproto(gpath, houston_proto):
+                    response = call_houston(gpath)
+                    assert (
+                        response.status_code == 200
+                    ), f'200 code not received on download: {gpath}'
                     with open(temp_filepath, 'wb') as temp_file_:
                         for chunk in response.iter_content(1024):
                             temp_file_.write(chunk)

--- a/wbia/control/manual_image_funcs.py
+++ b/wbia/control/manual_image_funcs.py
@@ -27,6 +27,7 @@ import numpy as np
 import utool as ut
 import vtool as vt
 from wbia.web import routes_ajax
+from wbia.utils import call_houston
 
 print, rrr, profile = ut.inject2(__name__)
 logger = logging.getLogger('wbia')
@@ -556,7 +557,8 @@ def localize_images(ibs, gid_list_=None):
 
     url_protos = ['https://', 'http://']
     s3_proto = ['s3://']
-    valid_protos = s3_proto + url_protos
+    houston_proto = ['houston+']
+    valid_protos = s3_proto + url_protos + houston_proto
 
     def isproto(uri, valid_protos):
         return any(uri.startswith(proto) for proto in valid_protos)
@@ -604,6 +606,14 @@ def localize_images(ibs, gid_list_=None):
                         response.status_code == 200
                     ), '200 code not received on download'
                 # Save
+                with open(loc_gpath, 'wb') as temp_file_:
+                    for chunk in response.iter_content(1024):
+                        temp_file_.write(chunk)
+            elif isproto(uri, houston_proto):
+                response = call_houston(uri)
+                assert (
+                    response.status_code == 200
+                ), f'200 code not received on download: {uri}'
                 with open(loc_gpath, 'wb') as temp_file_:
                     for chunk in response.iter_content(1024):
                         temp_file_.write(chunk)

--- a/wbia/tests/test_utils.py
+++ b/wbia/tests/test_utils.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+from oauthlib.oauth2 import TokenExpiredError
+from wbia.utils import call_houston
+
+
+def test_call_houston(request):
+    client_patch = mock.patch('wbia.utils.BackendApplicationClient')
+    BackendApplicationClient = client_patch.start()
+    request.addfinalizer(client_patch.stop)
+
+    session = mock.Mock()
+    session_patch = mock.patch('wbia.utils.OAuth2Session', return_value=session)
+    OAuth2Session = session_patch.start()
+    request.addfinalizer(session_patch.stop)
+
+    getenv_patch = mock.patch(
+        'wbia.utils.os.getenv',
+        side_effect={
+            'HOUSTON_CLIENT_ID': 'houston-client-id',
+            'HOUSTON_CLIENT_SECRET': 'houston-client-secret',
+        }.get,
+    )
+    getenv_patch.start()
+    request.addfinalizer(getenv_patch.stop)
+
+    response = mock.Mock()
+    session.request.return_value = response
+
+    # Case 1: Call houston for the first time
+    result = call_houston(
+        'houston+http://houston:5000/api/v1/users/me',
+        misc=10,
+    )
+    assert BackendApplicationClient.call_count == 1
+    assert OAuth2Session.call_count == 1
+    assert session.fetch_token.call_count == 1
+    assert session.fetch_token.call_args == mock.call(
+        token_url='http://houston:5000/api/v1/auth/tokens',
+        client_id='houston-client-id',
+        client_secret='houston-client-secret',
+    )
+    assert session.request.call_count == 1
+    assert session.request.call_args == mock.call(
+        'GET',
+        'http://houston:5000/api/v1/users/me',
+        misc=10,
+    )
+    assert result == response
+    BackendApplicationClient.reset_mock()
+    OAuth2Session.reset_mock()
+    session.request.reset_mock()
+    session.fetch_token.reset_mock()
+
+    # Case 2: Call houston again
+    result = call_houston('houston+http://houston:5000/favicon.ico')
+    assert not BackendApplicationClient.called
+    assert not OAuth2Session.called
+    assert not session.fetch_token.called
+    assert session.request.call_count == 1
+    assert session.request.call_args == mock.call(
+        'GET',
+        'http://houston:5000/favicon.ico',
+    )
+    assert result == response
+    session.request.reset_mock()
+
+    # Case 3: Token expired
+    def session_request(*args, **kwargs):
+        if session.request.call_count == 1:
+            raise TokenExpiredError
+        return response
+
+    session.request.side_effect = session_request
+    result = call_houston('houston+https://houston:5000/')
+    assert not BackendApplicationClient.called
+    assert not OAuth2Session.called
+    assert session.fetch_token.call_count == 1
+    assert session.fetch_token.call_args == mock.call(
+        token_url='https://houston:5000/api/v1/auth/tokens',
+        client_id='houston-client-id',
+        client_secret='houston-client-secret',
+    )
+    assert session.request.call_count == 2
+    assert session.request.call_args_list == [
+        mock.call('GET', 'https://houston:5000/'),
+        mock.call('GET', 'https://houston:5000/'),
+    ]

--- a/wbia/utils.py
+++ b/wbia/utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import os
+import urllib.parse
+
+from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
+from requests_oauthlib import OAuth2Session
+
+
+# Allow non-ssl communication
+os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+HOUSTON_TOKEN_API = '/api/v1/auth/tokens'
+
+
+def call_houston(uri, cached_session=[], method='GET', **kwargs):
+    HOUSTON_CLIENT_ID = os.getenv('HOUSTON_CLIENT_ID')
+    HOUSTON_CLIENT_SECRET = os.getenv('HOUSTON_CLIENT_SECRET')
+    uri = uri.replace('houston+', '')
+
+    def update_token():
+        token_url = urllib.parse.urljoin(uri, HOUSTON_TOKEN_API)
+        session.fetch_token(
+            token_url=token_url,
+            client_id=HOUSTON_CLIENT_ID,
+            client_secret=HOUSTON_CLIENT_SECRET,
+        )
+
+    if cached_session:
+        session = cached_session[0]
+    else:
+        client = BackendApplicationClient(client_id=HOUSTON_CLIENT_ID)
+        session = OAuth2Session(client=client)
+        cached_session.append(session)
+        update_token()
+
+    try:
+        return session.request(method, uri, **kwargs)
+    except TokenExpiredError:
+        update_token()
+        return session.request(method, uri, **kwargs)

--- a/wbia/web/apis_detect.py
+++ b/wbia/web/apis_detect.py
@@ -827,6 +827,12 @@ def detect_cnn_lightnet_json_wrapper(ibs, image_uuid_list, **kwargs):
 
 
 @register_ibs_method
+def detect_cnn_lightnet_image_uris_json(ibs, image_uris, config={}, **kwargs):
+    gid_list = ibs.add_images(image_uris, auto_localize=True)
+    return ibs.detect_cnn_lightnet_json(gid_list, config=config, **kwargs)
+
+
+@register_ibs_method
 @accessor_decors.getter_1to1
 def detect_cnn_lightnet_json(ibs, gid_list, config={}, **kwargs):
     return detect_cnn_json(

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -824,6 +824,7 @@ def start_detect_image_lightnet(
     image_uuid_list,
     callback_url=None,
     callback_method=None,
+    callback_detailed=False,
     lane='fast',
     jobid=None,
     **kwargs
@@ -851,7 +852,13 @@ def start_detect_image_lightnet(
             kwargs,
         )
         jobid = ibs.job_manager.jobiface.queue_job(
-            'detect_cnn_lightnet_json', callback_url, callback_method, lane, jobid, *args
+            'detect_cnn_lightnet_json',
+            callback_url,
+            callback_method,
+            callback_detailed,
+            lane,
+            jobid,
+            *args
         )
     else:
         # image_uuid_list contains urls
@@ -863,6 +870,7 @@ def start_detect_image_lightnet(
             'detect_cnn_lightnet_image_uris_json',
             callback_url,
             callback_method,
+            callback_detailed,
             lane,
             jobid,
             *args

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -834,24 +834,39 @@ def start_detect_image_lightnet(
         URL:
 
     Args:
-        image_uuid_list (list) : list of image uuids to detect on.
+        image_uuid_list (list) : list of image uuids or urls to detect on.
         callback_url (url) : url that will be called when detection succeeds or fails
     """
-    # Check UUIDs
-    ibs.web_check_uuids(image_uuid_list=image_uuid_list)
+    if image_uuid_list and '://' not in image_uuid_list[0]:
+        # Check UUIDs
+        ibs.web_check_uuids(image_uuid_list=image_uuid_list)
 
-    # import wbia
-    # from wbia.web import apis_engine
-    # ibs.load_plugin_module(apis_engine)
-    image_uuid_list = ensure_uuid_list(image_uuid_list)
-    gid_list = ibs.get_image_gids_from_uuid(image_uuid_list)
-    args = (
-        gid_list,
-        kwargs,
-    )
-    jobid = ibs.job_manager.jobiface.queue_job(
-        'detect_cnn_lightnet_json', callback_url, callback_method, lane, jobid, *args
-    )
+        # import wbia
+        # from wbia.web import apis_engine
+        # ibs.load_plugin_module(apis_engine)
+        image_uuid_list = ensure_uuid_list(image_uuid_list)
+        gid_list = ibs.get_image_gids_from_uuid(image_uuid_list)
+        args = (
+            gid_list,
+            kwargs,
+        )
+        jobid = ibs.job_manager.jobiface.queue_job(
+            'detect_cnn_lightnet_json', callback_url, callback_method, lane, jobid, *args
+        )
+    else:
+        # image_uuid_list contains urls
+        args = (
+            image_uuid_list,
+            kwargs,
+        )
+        jobid = ibs.job_manager.jobiface.queue_job(
+            'detect_cnn_lightnet_image_uris_json',
+            callback_url,
+            callback_method,
+            lane,
+            jobid,
+            *args
+        )
 
     # if callback_url is not None:
     #    #import requests


### PR DESCRIPTION
- Add support for fetching houston urls in add_images

  The urls need to be prepended with `houston+`, for example:
  
  ```
  houston+http://houston:5000/api/v1/users/me
  ```
  
  This tells wbia to use oauth2 authentication when fetching the url.

- Allow urls in /api/engine/detect/cnn/lightnet/ image_uuid_list

  When doing `POST /api/engine/detect/cnn/lightnet/`, if `image_uuid_list`
  has `://` it is going to download the images first before
  running detection.

- Support houston+ job callback urls and add callback_detailed

  OAuth2 authentication is necessary for the callback url that houston is
  sending so we need to support "houston+" callback urls.

  Also send all the data that you would get if you get the job results if
  `callback_detailed` is true, e.g.:
  
  ```
  {'status': 'completed',
   'jobid': '67bed230-01a8-464c-8421-b915e0467bca',
   'json_result': {
      'image_uuid_list': [
          {'__UUID__': '784eb312-2d7a-95a5-345c-6d0aeaa66853'},
          {'__UUID__': '51985f12-3628-4526-0545-fb47ab9a9732'}],
       'results_list': [[], []],
       'score_list': [0.0, 0.0],
       'has_assignments': False
   }
  }
  ```
