### PR TITLE
Sage 346 add status

### DIFF
--- a/wbia/web/job_engine.py
+++ b/wbia/web/job_engine.py
@@ -1890,7 +1890,7 @@ def on_collect_request(
     status = collect_request.get('status', None)
 
     reply = {
-        'status': 'ok',
+        'status': status,
         'jobid': jobid,
     }
 


### PR DESCRIPTION
One-liner adding status to the standard wbia callback. Previously status was always 'ok' despite not being the HTTP-level status. Easy PR!