### PR TITLE
Update oauth2 token if houston returns 401

### DIFF
--- a/wbia/utils.py
+++ b/wbia/utils.py
@@ -32,8 +32,15 @@ def call_houston(uri, cached_session=[], method='GET', **kwargs):
         cached_session.append(session)
         update_token()
 
-    try:
+    def get_response():
         return session.request(method, uri, **kwargs)
+
+    try:
+        resp = get_response()
+        if resp.status_code == 401:
+            update_token()
+            resp = get_response()
+        return resp
     except TokenExpiredError:
         update_token()
-        return session.request(method, uri, **kwargs)
+        return get_response()


### PR DESCRIPTION
Sometimes the oauth2 token isn't expired yet but needs to be updated
(e.g. if the token was removed from the houston db).  If houston returns
401, update the token and re-request.

---

The test failure is unrelated and is fixed in #201 :crossed_fingers: 