### PR TITLE
Add test for starting site (temporary)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -132,3 +132,8 @@ jobs:
       - name: Test project
         run: |
           pytest --slow --web-tests --with-postgres-uri='postgresql://postgres:wbia@localhost:5432/postgres'
+
+      - name: Start site
+        run: |
+          mkdir db
+          python -m wbia.dev --dbdir db/ --web


### PR DESCRIPTION
We need a way to stop the site probably but the site isn't starting anyway so I can't tell:

```
acm_1            | INFO:wbia:[main()] IBEIS LOAD encountered exception: <class 'ImportError'> cannot import name 'cached_property' from 'werkzeug' (/virtualenv/env3/lib/python3.7/site-packages/werkzeug/__init__.py)
acm_1            | Traceback (most recent call last):
acm_1            |   File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
acm_1            |     "__main__", mod_spec)
acm_1            |   File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
acm_1            |     exec(code, run_globals)
acm_1            |   File "/wbia/wildbook-ia/wbia/dev.py", line 1112, in <module>
acm_1            |     devmain()
acm_1            |   File "/wbia/wildbook-ia/wbia/dev.py", line 801, in devmain
acm_1            |     main_locals = wbia.main(gui=ut.get_argflag('--gui'))
acm_1            |   File "/wbia/wildbook-ia/wbia/entry_points.py", line 305, in main
acm_1            |     ibs = _init_wbia(dbdir)
acm_1            |   File "/wbia/wildbook-ia/wbia/entry_points.py", line 110, in _init_wbia
acm_1            |     app.start_from_wbia(ibs, port=port, **kwargs)
acm_1            |   File "/wbia/wildbook-ia/wbia/web/app.py", line 282, in start_from_wbia
acm_1            |     start_tornado(ibs, port, browser, url_suffix, start_web_loop)
acm_1            |   File "/wbia/wildbook-ia/wbia/web/app.py", line 230, in start_tornado
acm_1            |     _start_tornado(ibs, port)
acm_1            |   File "/wbia/wildbook-ia/wbia/web/app.py", line 103, in _start_tornado
acm_1            |     from wbia.web import extensions
acm_1            |   File "/wbia/wildbook-ia/wbia/web/extensions/__init__.py", line 50, in <module>
acm_1            |     from .auth import OAuth2Provider  # NOQA
acm_1            |   File "/wbia/wildbook-ia/wbia/web/extensions/auth/__init__.py", line 7, in <module>
acm_1            |     from .oauth2 import OAuth2Provider  # NOQA
acm_1            |   File "/wbia/wildbook-ia/wbia/web/extensions/auth/oauth2.py", line 22, in <module>
acm_1            |     from flask_restx_patched._http import HTTPStatus
acm_1            |   File "/wbia/wildbook-ia/flask_restx_patched/__init__.py", line 3, in <module>
acm_1            |     from .api import Api  # NOQA
acm_1            |   File "/wbia/wildbook-ia/flask_restx_patched/api.py", line 6, in <module>
acm_1            |     from werkzeug import cached_property
acm_1            | ImportError: cannot import name 'cached_property' from 'werkzeug' (/virtualenv/env3/lib/python3.7/site-packages/werkzeug/__init__.py)
```