### PR TITLE
Make localhost work in callbacks

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,7 +69,14 @@ jobs:
         run: |
           pip install -e .[tests,problematic]
           mkdir -p /tmp/work
-          PYTHONFAULTHANDLER=1 python -m wbia --set-workdir /tmp/work --preload-exit
+          python -X faulthandler -m wbia --set-workdir /tmp/work --preload-exit
+
+      - name: gdb backtrace (if failed)
+        if: failure()
+        run: |
+          set -x
+          sudo apt-get install -y gdb
+          echo -e "r\nbt\nq" | gdb --args python -m wbia --set-workdir /tmp/work --preload-exit
 
       - name: Test project
         run: |

--- a/devops/_config/setup.sh
+++ b/devops/_config/setup.sh
@@ -65,3 +65,7 @@ fi
 
 # Allow Tensorflow to use GPU memory more dynamically
 export TF_FORCE_GPU_ALLOW_GROWTH=true
+
+# Comment out localhost from /etc/hosts for development
+sed 's/^\([^#].*localhost\)/# \1/' /etc/hosts >/etc/hosts.new
+cat /etc/hosts.new >/etc/hosts

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -34,6 +34,7 @@ keras
 line-profiler
 lockfile
 mako
+MarkupSafe<2.1.0
 # marshmallow
 # marshmallow-sqlalchemy
 matplotlib

--- a/wbia/web/job_engine.py
+++ b/wbia/web/job_engine.py
@@ -2092,8 +2092,12 @@ def on_collect_request(
         engine_result = None  # Release memory
 
         if callback_url is not None:
-            if containerized:
-                callback_url = callback_url.replace('://localhost/', '://wildbook:8080/')
+            # We are using localhost as the name of the houston nginx service
+            # so we need localhost to work as is, so commenting out the code
+            # below:
+            #
+            # if containerized:
+            #     callback_url = callback_url.replace('://localhost/', '://wildbook:8080/')
 
             if callback_method is None:
                 callback_method = 'POST'


### PR DESCRIPTION
- Comment out localhost from /etc/hosts in docker container

  We are using localhost as the nginx service name so we can avoid using
  http://houston:5000/ in development.
  
  From houston we call the detection API
  `/api/engine/detect/cnn/lightnet/` with a list of image urls and a
  callback url.  In development, "http://localhost/" is the url for the
  site, but acm wouldn't be able to access a url at localhost unless we
  remove the definition of localhost from `/etc/hosts`.

- Downgrade MarkupSafe<2.1.0 in requirements/runtime.txt

  MarkupSafe 2.1.0 removed a deprecated function `soft_unicode` which
  jinja2 imports, causing wildbook-ia to fail:
  
  ```
  Traceback (most recent call last):
  
  +------
  
  <!!! EXCEPTION !!!>
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sentry_sdk/integrations/flask.py", line 29, in <module>
      from flask import (  # type: ignore
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/flask/__init__.py", line 14, in <module>
      from jinja2 import escape
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py", line 12, in <module>
      from .environment import Environment
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/environment.py", line 25, in <module>
      from .defaults import BLOCK_END_STRING
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/defaults.py", line 3, in <module>
      from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/filters.py", line 13, in <module>
      from markupsafe import soft_unicode
  ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/markupsafe/__init__.py)
  ```

- Add python and c back trace if python -m wbia fails in github CI

  Change `PYTHONFAULTHANDLER=1` to `-X faulthandler` as
  `PYTHONFAULTHANDLER=1` doesn't seem to print out the python back trace
  when there's segmentation fault.
  
  If there's an error, run `gdb` to get a c back trace.

- Comment out code to replace localhost with wildbook-ia in callback urls

  We are using localhost as the name of the houston nginx service for
  local development so we need to leave localhost as is.
