### PR TITLE
Conforms all imports of wbia.const 

### DIFF
--- a/wbia/algo/detect/grabmodels.py
+++ b/wbia/algo/detect/grabmodels.py
@@ -45,8 +45,9 @@ def get_species_trees_paths(species, modeldir='default'):
         >>> # ENABLE_DOCTEST
         >>> from wbia.algo.detect.grabmodels import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> # build test data
-        >>> species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> species = const.TEST_SPECIES.ZEB_PLAIN
         >>> modeldir = 'default'
         >>> # execute function
         >>> trees_path = get_species_trees_paths(species, modeldir)

--- a/wbia/algo/detect/randomforest.py
+++ b/wbia/algo/detect/randomforest.py
@@ -222,9 +222,10 @@ def detect_gid_list_with_species(ibs, gid_list, species, downsample=True, **kwar
         >>> from wbia.algo.detect.randomforest import *  # NOQA
         >>> from wbia.algo.detect.randomforest import _get_models  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> # build test data
         >>> ibs = wbia.opendb('testdb1')
-        >>> species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> species = const.TEST_SPECIES.ZEB_PLAIN
         >>> gid_list = ibs.get_valid_gids()
         >>> downsample = True
         >>> kwargs = {}
@@ -358,8 +359,9 @@ def _get_models(ibs, species, modeldir='default', cfg_override=True, verbose=VER
         >>> # ENABLE_DOCTEST
         >>> from wbia.algo.detect.randomforest import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> ibs = wbia.opendb(defaultdb='testdb1')
-        >>> species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> species = const.TEST_SPECIES.ZEB_PLAIN
         >>> modeldir = 'default'
         >>> cfg_override = True
         >>> verbose = False

--- a/wbia/algo/hots/neighbor_index_cache.py
+++ b/wbia/algo/hots/neighbor_index_cache.py
@@ -208,8 +208,9 @@ def build_nnindex_cfgstr(qreq_, daid_list):
         >>> # ENABLE_DOCTEST
         >>> from wbia.algo.hots.neighbor_index_cache import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> ibs = wbia.opendb(db='testdb1')
-        >>> daid_list = ibs.get_valid_aids(species=wbia.const.TEST_SPECIES.ZEB_PLAIN)
+        >>> daid_list = ibs.get_valid_aids(species=const.TEST_SPECIES.ZEB_PLAIN)
         >>> qreq_ = ibs.new_query_request(daid_list, daid_list, cfgdict=dict(fg_on=False))
         >>> nnindex_cfgstr = build_nnindex_cfgstr(qreq_, daid_list)
         >>> result = str(nnindex_cfgstr)
@@ -332,8 +333,9 @@ def request_augmented_wbia_nnindexer(
         >>> # ENABLE_DOCTEST
         >>> from wbia.algo.hots.neighbor_index_cache import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> # build test data
-        >>> ZEB_PLAIN = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> ZEB_PLAIN = const.TEST_SPECIES.ZEB_PLAIN
         >>> ibs = wbia.opendb('testdb1')
         >>> use_memcache, max_covers, verbose = True, None, True
         >>> daid_list = sorted(ibs.get_valid_aids(species=ZEB_PLAIN))[0:6]
@@ -456,10 +458,11 @@ def request_memcached_wbia_nnindexer(
         >>> # DISABLE_DOCTEST
         >>> from wbia.algo.hots.neighbor_index_cache import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> # build test data
         >>> ibs = wbia.opendb('testdb1')
         >>> qreq_.qparams.min_reindex_thresh = 3
-        >>> ZEB_PLAIN = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> ZEB_PLAIN = const.TEST_SPECIES.ZEB_PLAIN
         >>> daid_list = ibs.get_valid_aids(species=ZEB_PLAIN)[0:3]
         >>> qreq_ = ibs.new_query_request(daid_list, daid_list)
         >>> verbose = True
@@ -549,9 +552,10 @@ def request_diskcached_wbia_nnindexer(
         >>> # DISABLE_DOCTEST
         >>> from wbia.algo.hots.neighbor_index_cache import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> # build test data
         >>> ibs = wbia.opendb('testdb1')
-        >>> daid_list = ibs.get_valid_aids(species=wbia.const.TEST_SPECIES.ZEB_PLAIN)
+        >>> daid_list = ibs.get_valid_aids(species=const.TEST_SPECIES.ZEB_PLAIN)
         >>> qreq_ = ibs.new_query_request(daid_list, daid_list)
         >>> nnindex_cfgstr = build_nnindex_cfgstr(qreq_, daid_list)
         >>> verbose = True
@@ -619,8 +623,9 @@ def group_daids_by_cached_nnindexer(
         >>> # ENABLE_DOCTEST
         >>> from wbia.algo.hots.neighbor_index_cache import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> ibs = wbia.opendb('testdb1')
-        >>> ZEB_PLAIN = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> ZEB_PLAIN = const.TEST_SPECIES.ZEB_PLAIN
         >>> daid_list = ibs.get_valid_aids(species=ZEB_PLAIN)
         >>> qreq_ = ibs.new_query_request(daid_list, daid_list)
         >>> # Set the params a bit lower
@@ -820,9 +825,10 @@ def request_background_nnindexer(qreq_, daid_list):
         >>> # DISABLE_DOCTEST
         >>> from wbia.algo.hots.neighbor_index_cache import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> # build test data
         >>> ibs = wbia.opendb('testdb1')
-        >>> daid_list = ibs.get_valid_aids(species=wbia.const.TEST_SPECIES.ZEB_PLAIN)
+        >>> daid_list = ibs.get_valid_aids(species=const.TEST_SPECIES.ZEB_PLAIN)
         >>> qreq_ = ibs.new_query_request(daid_list, daid_list)
         >>> # execute function
         >>> request_background_nnindexer(qreq_, daid_list)

--- a/wbia/algo/hots/query_request.py
+++ b/wbia/algo/hots/query_request.py
@@ -15,7 +15,7 @@ import numpy as np
 import utool as ut
 import vtool as vt
 
-import wbia.constants as const
+from wbia import constants as const
 from wbia import dtool
 
 # from wbia.algo.hots import multi_index
@@ -769,7 +769,7 @@ class QueryRequest(ut.NiceRepr):
     #        >>> import wbia
     #        >>> # build test data
     #        >>> ibs = wbia.opendb('testdb1')
-    #        >>> species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+    #        >>> species = const.TEST_SPECIES.ZEB_PLAIN
     #        >>> daids = ibs.get_valid_aids(species=species, is_exemplar=True)
     #        >>> qaids = ibs.get_valid_aids(species=species, is_exemplar=False)
     #        >>> qreq_ = ibs.new_query_request(qaids, daids)

--- a/wbia/control/manual_annot_funcs.py
+++ b/wbia/control/manual_annot_funcs.py
@@ -1973,7 +1973,7 @@ def get_annot_yaws(ibs, aid_list, assume_unique=False):
         tau = 2 * pi
 
     SeeAlso:
-        const.VIEWTEXT_TO_YAW_RADIANS
+        wbia.constants.VIEWTEXT_TO_YAW_RADIANS
 
     Returns:
         yaw_list (list): the yaw (in radians) for the annotation
@@ -2265,7 +2265,7 @@ def set_annot_yaws(ibs, aid_list, yaw_list, input_is_degrees=False):
             (tau = 2 * pi)
 
     SeeAlso:
-        const.VIEWTEXT_TO_YAW_RADIANS
+        wbia.constants.VIEWTEXT_TO_YAW_RADIANS
 
     References:
         http://upload.wikimedia.org/wikipedia/commons/7/7e/Rollpitchyawplain.png
@@ -3580,7 +3580,7 @@ def get_annot_qualities(ibs, aid_list, eager=True):
         tbl = annot
 
     SeeAlso:
-        const.QUALITY_INT_TO_TEXT
+        wbia.constants.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: GET
@@ -3625,7 +3625,7 @@ def set_annot_qualities(ibs, aid_list, annot_quality_list):
         annot_quality_list
 
     SeeAlso:
-        const.QUALITY_INT_TO_TEXT
+        wbia.constants.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: PUT

--- a/wbia/control/manual_annot_funcs.py
+++ b/wbia/control/manual_annot_funcs.py
@@ -1973,7 +1973,7 @@ def get_annot_yaws(ibs, aid_list, assume_unique=False):
         tau = 2 * pi
 
     SeeAlso:
-        wbia.const.VIEWTEXT_TO_YAW_RADIANS
+        const.VIEWTEXT_TO_YAW_RADIANS
 
     Returns:
         yaw_list (list): the yaw (in radians) for the annotation
@@ -2265,7 +2265,7 @@ def set_annot_yaws(ibs, aid_list, yaw_list, input_is_degrees=False):
             (tau = 2 * pi)
 
     SeeAlso:
-        wbia.const.VIEWTEXT_TO_YAW_RADIANS
+        const.VIEWTEXT_TO_YAW_RADIANS
 
     References:
         http://upload.wikimedia.org/wikipedia/commons/7/7e/Rollpitchyawplain.png
@@ -3580,7 +3580,7 @@ def get_annot_qualities(ibs, aid_list, eager=True):
         tbl = annot
 
     SeeAlso:
-        wbia.const.QUALITY_INT_TO_TEXT
+        const.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: GET
@@ -3625,7 +3625,7 @@ def set_annot_qualities(ibs, aid_list, annot_quality_list):
         annot_quality_list
 
     SeeAlso:
-        wbia.const.QUALITY_INT_TO_TEXT
+        const.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: PUT

--- a/wbia/control/manual_part_funcs.py
+++ b/wbia/control/manual_part_funcs.py
@@ -721,7 +721,7 @@ def get_part_qualities(ibs, part_rowid_list, eager=True):
         tbl = part
 
     SeeAlso:
-        const.QUALITY_INT_TO_TEXT
+        wbia.constants.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: GET
@@ -1245,7 +1245,7 @@ def set_part_qualities(ibs, part_rowid_list, part_quality_list):
         part_quality_list
 
     SeeAlso:
-        const.QUALITY_INT_TO_TEXT
+        wbia.constants.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: PUT

--- a/wbia/control/manual_part_funcs.py
+++ b/wbia/control/manual_part_funcs.py
@@ -721,7 +721,7 @@ def get_part_qualities(ibs, part_rowid_list, eager=True):
         tbl = part
 
     SeeAlso:
-        wbia.const.QUALITY_INT_TO_TEXT
+        const.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: GET
@@ -1245,7 +1245,7 @@ def set_part_qualities(ibs, part_rowid_list, part_quality_list):
         part_quality_list
 
     SeeAlso:
-        wbia.const.QUALITY_INT_TO_TEXT
+        const.QUALITY_INT_TO_TEXT
 
     RESTful:
         Method: PUT

--- a/wbia/control/wildbook_manager.py
+++ b/wbia/control/wildbook_manager.py
@@ -22,6 +22,8 @@ from os.path import basename, dirname, join, splitext
 
 import utool as ut
 
+from wbia import constants as const
+
 print, rrr, profile = ut.inject2(__name__)
 logger = logging.getLogger('wbia')
 
@@ -163,10 +165,8 @@ def find_installed_tomcat(check_unpacked=True, strict=True):
             logger.info(msg)
             return None
     if check_unpacked:
-        import wbia
-
         # Check that webapps was unpacked
-        wb_target = wbia.const.WILDBOOK_TARGET
+        wb_target = const.WILDBOOK_TARGET
         webapps_dpath = join(tomcat_dpath, 'webapps')
         unpacked_war_dpath = join(webapps_dpath, wb_target)
         ut.assertpath(unpacked_war_dpath)
@@ -469,7 +469,7 @@ def update_wildbook_install_config(webapps_dpath, unpacked_war_dpath):
         >>> import wbia
         >>> tomcat_dpath = find_installed_tomcat()
         >>> webapps_dpath = join(tomcat_dpath, 'webapps')
-        >>> wb_target = wbia.const.WILDBOOK_TARGET
+        >>> wb_target = const.WILDBOOK_TARGET
         >>> unpacked_war_dpath = join(webapps_dpath, wb_target)
         >>> locals_ = ut.exec_func_src(update_wildbook_install_config, globals())
         >>> #update_wildbook_install_config(webapps_dpath, unpacked_war_dpath)
@@ -669,15 +669,13 @@ def startup_wildbook_server(verbose=ut.NOT_QUIET):
         >>> ut.get_prefered_browser(PREFERED_BROWSER).open_new_tab(wb_url)
     """
     # TODO: allow custom specified tomcat directory
-    import wbia
-
     tomcat_dpath = find_installed_tomcat()
 
     with ut.ChdirContext(get_tomcat_startup_tmpdir()):
         startup_fpath = join(tomcat_dpath, 'bin', 'startup.sh')
         ut.cmd(ut.quote_single_command(startup_fpath))
         time.sleep(1)
-    wb_url = 'http://127.0.0.1:8080/' + wbia.const.WILDBOOK_TARGET
+    wb_url = 'http://127.0.0.1:8080/' + const.WILDBOOK_TARGET
     # TODO go to http://127.0.0.1:8080/wbia/createAssetStore.jsp
     return wb_url
 
@@ -729,15 +727,13 @@ def monitor_wildbook_logs(verbose=ut.NOT_QUIET):
         >>> monitor_wildbook_logs()
     """
     # TODO: allow custom specified tomcat directory
-    import wbia
-
     tomcat_dpath = find_installed_tomcat()
 
     with ut.ChdirContext(get_tomcat_startup_tmpdir()):
         startup_fpath = join(tomcat_dpath, 'bin', 'startup.sh')
         ut.cmd(ut.quote_single_command(startup_fpath))
         time.sleep(1)
-    wb_url = 'http://127.0.0.1:8080/' + wbia.const.WILDBOOK_TARGET
+    wb_url = 'http://127.0.0.1:8080/' + const.WILDBOOK_TARGET
     return wb_url
 
 
@@ -757,10 +753,8 @@ def tryout_wildbook_login():
         >>> tryout_wildbook_login()
     """
     # Use selenimum to login to wildbook
-    import wbia
-
     manaul_login = False
-    wb_target = wbia.const.WILDBOOK_TARGET
+    wb_target = const.WILDBOOK_TARGET
     wb_url = 'http://127.0.0.1:8080/' + wb_target
     if manaul_login:
         ut.get_prefered_browser(PREFERED_BROWSER).open_new_tab(wb_url)

--- a/wbia/dbio/export_subset.py
+++ b/wbia/dbio/export_subset.py
@@ -1291,11 +1291,11 @@ def check_database_overlap(ibs1, ibs2):
 
 """
 def MERGE_NNP_MASTER_SCRIPT():
-    logger.info(ut.truncate_str(ibs_dst.db.get_table_csv(wbia.const.ANNOTATION_TABLE,
+    logger.info(ut.truncate_str(ibs_dst.db.get_table_csv(const.ANNOTATION_TABLE,
         exclude_columns=['annot_verts', 'annot_semantic_uuid', 'annot_note', 'annot_parent_rowid']), 10000))
-    logger.info(ut.truncate_str(ibs_src1.db.get_table_csv(wbia.const.ANNOTATION_TABLE,
+    logger.info(ut.truncate_str(ibs_src1.db.get_table_csv(const.ANNOTATION_TABLE,
         exclude_columns=['annot_verts', 'annot_semantic_uuid', 'annot_note', 'annot_parent_rowid']), 10000))
-    logger.info(ut.truncate_str(ibs_src1.db.get_table_csv(wbia.const.ANNOTATION_TABLE), 10000))
+    logger.info(ut.truncate_str(ibs_src1.db.get_table_csv(const.ANNOTATION_TABLE), 10000))
 
     from wbia.dbio.export_subset import *  # NOQA
     import wbia

--- a/wbia/dbio/ingest_database.py
+++ b/wbia/dbio/ingest_database.py
@@ -1684,7 +1684,7 @@ def ingest_serengeti_mamal_cameratrap(species):
         >>> # SCRIPT
         >>> from wbia.dbio.ingest_database import *  # NOQA
         >>> import wbia
-        >>> species = ut.get_argval('--species', type_=str, default=wbia.const.TEST_SPECIES.ZEB_PLAIN)
+        >>> species = ut.get_argval('--species', type_=str, default=const.TEST_SPECIES.ZEB_PLAIN)
         >>> # species = ut.get_argval('--species', type_=str, default='cheetah')
         >>> result = ingest_serengeti_mamal_cameratrap(species)
         >>> print(result)

--- a/wbia/init/sysres.py
+++ b/wbia/init/sysres.py
@@ -636,9 +636,7 @@ def copy_wbiadb(source_dbdir, dest_dbdir):
     # TODO: rectify with rsync, script, and merge script.
     from os.path import normpath
 
-    import wbia
-
-    exclude_dirs_ = wbia.const.EXCLUDE_COPY_REL_DIRS + ['_hsdb', '.hs_internals']
+    exclude_dirs_ = const.EXCLUDE_COPY_REL_DIRS + ['_hsdb', '.hs_internals']
     exclude_dirs = [ut.ensure_unixslash(normpath(rel)) for rel in exclude_dirs_]
 
     rel_tocopy = ut.glob(

--- a/wbia/other/ibsfuncs.py
+++ b/wbia/other/ibsfuncs.py
@@ -3312,7 +3312,7 @@ def get_primary_species_viewpoint(species, plus=0):
         >>> # ENABLE_DOCTEST
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
-        >>> species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> species = const.TEST_SPECIES.ZEB_PLAIN
         >>> aid_subset = get_primary_species_viewpoint(species, 0)
         >>> result = ('aid_subset = %s' % (str(aid_subset),))
         >>> print(result)
@@ -5226,7 +5226,7 @@ def filter_aids_to_species(ibs, aid_list, species, speedhack=True):
         >>> import wbia
         >>> ibs = wbia.opendb(defaultdb='testdb1')
         >>> aid_list = ibs.get_valid_aids()
-        >>> species = wbia.const.TEST_SPECIES.ZEB_GREVY
+        >>> species = const.TEST_SPECIES.ZEB_GREVY
         >>> aid_list_ = filter_aids_to_species(ibs, aid_list, species)
         >>> result = 'aid_list_ = %r' % (aid_list_,)
         >>> print(result)

--- a/wbia/other/ibsfuncs.py
+++ b/wbia/other/ibsfuncs.py
@@ -2481,6 +2481,7 @@ def get_ungrouped_gids(ibs):
         >>> # ENABLE_DOCTEST
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia  # NOQA
+        >>> from wbia import constants as const
         >>> ibs = wbia.opendb('testdb1')
         >>> ibs.delete_all_imagesets()
         >>> ibs.compute_occurrences(config={'use_gps': False, 'seconds_thresh': 600})
@@ -3135,6 +3136,7 @@ def make_next_name(ibs, num=None, str_format=2, species_text=None, location_text
         >>> # ENABLE_DOCTEST
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> ibs1 = wbia.opendb('testdb1')
         >>> ibs2 = wbia.opendb('PZ_MTEST')
         >>> ibs3 = wbia.opendb('NAUT_test')
@@ -3312,6 +3314,7 @@ def get_primary_species_viewpoint(species, plus=0):
         >>> # ENABLE_DOCTEST
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> species = const.TEST_SPECIES.ZEB_PLAIN
         >>> aid_subset = get_primary_species_viewpoint(species, 0)
         >>> result = ('aid_subset = %s' % (str(aid_subset),))
@@ -5224,6 +5227,7 @@ def filter_aids_to_species(ibs, aid_list, species, speedhack=True):
         >>> # ENABLE_DOCTEST
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> ibs = wbia.opendb(defaultdb='testdb1')
         >>> aid_list = ibs.get_valid_aids()
         >>> species = const.TEST_SPECIES.ZEB_GREVY
@@ -5554,6 +5558,7 @@ def group_annots_by_multi_prop(ibs, aids, getter_list):
 def group_prop_edges(prop2_nid2_aids, prop_basis, size=2, wrap=True):
     """
     from wbia.other.ibsfuncs import *  # NOQA
+    from wbia import constants as const
     getter_func = ibs.get_annot_viewpoints
     prop_basis = list(const.VIEWTEXT_TO_YAW_RADIANS.keys())
     size = 2
@@ -6904,6 +6909,7 @@ def compute_occurrences(ibs, config=None):
         >>> # ENABLE_DOCTEST
         >>> from wbia.control.IBEISControl import *  # NOQA
         >>> import wbia  # NOQA
+        >>> from wbia import constants as const
         >>> ibs = wbia.opendb('testdb1')
         >>> ibs.compute_occurrences(config={'use_gps': False, 'seconds_thresh': 600})
         >>> ibs.update_special_imagesets()

--- a/wbia/scripts/rsync_wbiadb.py
+++ b/wbia/scripts/rsync_wbiadb.py
@@ -9,6 +9,8 @@ import logging
 
 import utool as ut
 
+from wbia import constants as const
+
 (print, rrr, profile) = ut.inject2(__name__)
 logger = logging.getLogger('wbia')
 
@@ -27,7 +29,7 @@ def sync_wbiadb(remote_uri, dbname, mode='pull', workdir=None, port=22, dryrun=F
 
     assert dbname is not None, 'must specify a database name'
     # Excluded temporary and cached data
-    exclude_dirs = list(map(ut.ensure_unixslash, wbia.const.EXCLUDE_COPY_REL_DIRS))
+    exclude_dirs = list(map(ut.ensure_unixslash, const.EXCLUDE_COPY_REL_DIRS))
     # Specify local workdir
     if workdir is None:
         workdir = wbia.sysres.get_workdir()

--- a/wbia/unstable/distinctiveness_normalizer.py
+++ b/wbia/unstable/distinctiveness_normalizer.py
@@ -60,7 +60,7 @@ def testdata_distinctiveness():
         species = ibs.get_annot_species_texts(aid)
     if species is None:
         if db == 'testdb1':
-            species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+            species = const.TEST_SPECIES.ZEB_PLAIN
     daids = ibs.get_valid_aids(species=species)
     qaids = [aid] if aid is not None else daids
     qreq_ = ibs.new_query_request(qaids, daids)
@@ -425,8 +425,8 @@ def request_wbia_distinctiveness_normalizer(qreq_, verbose=True):
         >>> import wbia
         >>> # build test data
         >>> ibs = wbia.opendb('testdb1')
-        >>> daids = ibs.get_valid_aids(species=wbia.const.TEST_SPECIES.ZEB_PLAIN)
-        >>> qaids = ibs.get_valid_aids(species=wbia.const.TEST_SPECIES.ZEB_PLAIN)
+        >>> daids = ibs.get_valid_aids(species=const.TEST_SPECIES.ZEB_PLAIN)
+        >>> qaids = ibs.get_valid_aids(species=const.TEST_SPECIES.ZEB_PLAIN)
         >>> qreq_ = ibs.new_query_request(qaids, daids)
         >>> # execute function
         >>> dstcnvs_normer = request_wbia_distinctiveness_normalizer(qreq_)

--- a/wbia/unstable/distinctiveness_normalizer.py
+++ b/wbia/unstable/distinctiveness_normalizer.py
@@ -423,6 +423,7 @@ def request_wbia_distinctiveness_normalizer(qreq_, verbose=True):
         >>> # SLOW_DOCTEST
         >>> from wbia.algo.hots.distinctiveness_normalizer import *  # NOQA
         >>> import wbia
+        >>> from wbia import constants as const
         >>> # build test data
         >>> ibs = wbia.opendb('testdb1')
         >>> daids = ibs.get_valid_aids(species=const.TEST_SPECIES.ZEB_PLAIN)

--- a/wbia/unstable/scorenorm.py
+++ b/wbia/unstable/scorenorm.py
@@ -262,6 +262,7 @@ def get_global_species_scorenorm_cachedir(ibs, species_text, ensure=True):
         >>> from wbia.control.IBEISControl import *  # NOQA
         >>> from wbia.unstable.scorenorm import get_global_species_scorenorm_cachedir
         >>> import wbia  # NOQA
+        >>> from wbia import constants as const
         >>> ibs = wbia.opendb('testdb1')
         >>> species_text = const.TEST_SPECIES.ZEB_GREVY
         >>> ensure = True

--- a/wbia/unstable/scorenorm.py
+++ b/wbia/unstable/scorenorm.py
@@ -263,7 +263,7 @@ def get_global_species_scorenorm_cachedir(ibs, species_text, ensure=True):
         >>> from wbia.unstable.scorenorm import get_global_species_scorenorm_cachedir
         >>> import wbia  # NOQA
         >>> ibs = wbia.opendb('testdb1')
-        >>> species_text = wbia.const.TEST_SPECIES.ZEB_GREVY
+        >>> species_text = const.TEST_SPECIES.ZEB_GREVY
         >>> ensure = True
         >>> species_cachedir = get_global_species_scorenorm_cachedir(ibs, species_text, ensure)
         >>> resourcedir = ibs.get_wbia_resource_dir()

--- a/wbia/viz/viz_graph2.py
+++ b/wbia/viz/viz_graph2.py
@@ -12,9 +12,9 @@ import numpy as np
 import utool as ut
 import vtool as vt
 
-import wbia.constants as const
 import wbia.guitool as gt
 import wbia.plottool as pt
+from wbia import constants as const
 from wbia import dtool
 from wbia.algo.graph.state import INCMP, NEGTV, POSTV, UNKWN, UNREV  # NOQA
 from wbia.guitool import PrefWidget2, mpl_widget
@@ -516,14 +516,12 @@ class EdgeReviewDialog(gt.GuitoolWidget):
         user_id=None,
     ):
         # from wbia.guitool.__PYQT__ import QtWidgets
-        import wbia
-
         if user_id is None:
             user_id = ut.get_user_name() + '@' + ut.get_computer_name() + ':qt'
 
-        EVIDENCE_DECISION = wbia.const.EVIDENCE_DECISION
+        EVIDENCE_DECISION = const.EVIDENCE_DECISION
         # TODO: meta decision
-        CONFIDENCE = wbia.const.CONFIDENCE
+        CONFIDENCE = const.CONFIDENCE
 
         match_state_codes = list(EVIDENCE_DECISION.CODE_TO_INT.keys())
         user_conf_codes = list(CONFIDENCE.CODE_TO_INT.keys())
@@ -694,15 +692,13 @@ class EdgeReviewDialog(gt.GuitoolWidget):
         self.close()
 
     def feedback_dict(self):
-        import wbia
-
         decision_nice = self.match_state_combo.currentText()
         conf_nice = self.conf_combo.currentText()
-        decision_code = wbia.const.EVIDENCE_DECISION.NICE_TO_CODE[decision_nice]
+        decision_code = const.EVIDENCE_DECISION.NICE_TO_CODE[decision_nice]
         tags = [key for key, check in self.tag_checkboxes.items() if check.checkState()]
         tags += self.pairtag_edit.tags()
         tags = [t for t in tags if len(t) != 0]
-        confidence = wbia.const.CONFIDENCE.NICE_TO_CODE[conf_nice]
+        confidence = const.CONFIDENCE.NICE_TO_CODE[conf_nice]
         user_id = self.user_edit.text()
         feedback = {
             'edge': self.edge,

--- a/wbia/web/apis_detect.py
+++ b/wbia/web/apis_detect.py
@@ -79,7 +79,7 @@ def wic_cnn_json(ibs, gid_list, config={}, **kwargs):
 #         >>> import wbia
 #         >>> ibs = wbia.opendb('testdb1')
 #         >>> gid_list = ibs.get_valid_gids()[0:2]
-#         >>> species = cons.TEST_SPECIES.ZEB_PLAIN
+#         >>> species = const.TEST_SPECIES.ZEB_PLAIN
 #         >>> aids_list = ibs.detect_random_forest(gid_list, species)
 #         >>> # Visualize results
 #         >>> if ut.show_was_requested():

--- a/wbia/web/apis_detect.py
+++ b/wbia/web/apis_detect.py
@@ -79,7 +79,7 @@ def wic_cnn_json(ibs, gid_list, config={}, **kwargs):
 #         >>> import wbia
 #         >>> ibs = wbia.opendb('testdb1')
 #         >>> gid_list = ibs.get_valid_gids()[0:2]
-#         >>> species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+#         >>> species = cons.TEST_SPECIES.ZEB_PLAIN
 #         >>> aids_list = ibs.detect_random_forest(gid_list, species)
 #         >>> # Visualize results
 #         >>> if ut.show_was_requested():


### PR DESCRIPTION
to 'from wbia import constants as const'. Removes now-unused instances of 'import wbia'. Changes all wbia.const.X to const.X.

In some cases these changes were just in the tests.

I've run this branch and the two plugin branches on Cthulhu and no longer hit the error we had this morning.