### PR TITLE
Docker write error patch

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -3,7 +3,7 @@ name: Build and upload Docker
 on:
   push:
     branches:
-      - main
+      - docker-write-error-patch
     tags:
       - v*
   schedule:

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -3,7 +3,7 @@ name: Build and upload Docker
 on:
   push:
     branches:
-      - docker-write-error-patch
+      - main
     tags:
       - v*
   schedule:

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -127,6 +127,8 @@ RUN set -ex \
      opencv-contrib-python-headless \
  && /virtualenv/env3/bin/pip install --upgrade \
      opencv-contrib-python-headless
+ && /virtualenv/env3/bin/ pip uninstall -y \
+     nvidia_cublas_cu11
 
 # Run smoke tests
 RUN set -ex \

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -126,7 +126,7 @@ RUN set -ex \
      opencv-python-headless \
      opencv-contrib-python-headless \
  && /virtualenv/env3/bin/pip install --upgrade \
-     opencv-contrib-python-headless
+     opencv-contrib-python-headless \
  && /virtualenv/env3/bin/ pip uninstall -y \
      nvidia_cublas_cu11
 

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -127,7 +127,7 @@ RUN set -ex \
      opencv-contrib-python-headless \
  && /virtualenv/env3/bin/pip install --upgrade \
      opencv-contrib-python-headless \
- && /virtualenv/env3/bin/ pip uninstall -y \
+ && /virtualenv/env3/bin/pip uninstall -y \
      nvidia_cublas_cu11
 
 # Run smoke tests

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -91,9 +91,9 @@ COPY ./_config/healthcheck.py /bin/healthcheck.py
 RUN updatedb
 
 # Temporary fix for ARM64
-ENV LD_PRELOAD "${LD_PRELOAD}:/virtualenv/env3/lib/python3.7/site-packages/torch/lib/libgomp-d22c30c5.so.1"
+#ENV LD_PRELOAD "${LD_PRELOAD}:/virtualenv/env3/lib/python3.7/site-packages/torch/lib/libgomp-d22c30c5.so.1"
 
-ENV LD_PRELOAD "${LD_PRELOAD}:/virtualenv/env3/lib/python3.7/site-packages/scikit_image.libs/libgomp-d22c30c5.so.1.0.0"
+#ENV LD_PRELOAD "${LD_PRELOAD}:/virtualenv/env3/lib/python3.7/site-packages/scikit_image.libs/libgomp-d22c30c5.so.1.0.0"
 
 # Fix PyQt5
 RUN set -ex \

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -74,8 +74,8 @@ sqlalchemy==1.4.14
 SQLAlchemy-Utils==0.38.3
 tensorboard_logger==0.1.0
 Theano==1.0.5
-torch==1.13.1
-torchvision==0.14.1
+torch==1.13.1+cu116
+torchvision==0.14.1+cu116
 tornado==6.2
 tqdm==4.64.0
 ubelt==1.2.1

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -74,8 +74,9 @@ sqlalchemy==1.4.14
 SQLAlchemy-Utils==0.38.3
 tensorboard_logger==0.1.0
 Theano==1.0.5
-torch==1.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
-torchvision==0.14.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+torchaudio==0.12.1
 tornado==6.2
 tqdm==4.64.0
 ubelt==1.2.1

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -74,8 +74,8 @@ sqlalchemy==1.4.14
 SQLAlchemy-Utils==0.38.3
 tensorboard_logger==0.1.0
 Theano==1.0.5
-torch==1.13.1+cu116
-torchvision==0.14.1+cu116
+torch==1.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+torchvision==0.14.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
 tornado==6.2
 tqdm==4.64.0
 ubelt==1.2.1

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -74,8 +74,8 @@ sqlalchemy==1.4.14
 SQLAlchemy-Utils==0.38.3
 tensorboard_logger==0.1.0
 Theano==1.0.5
-torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
-torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+torch==1.12.1+cu113
+torchvision==0.13.1+cu113
 torchaudio==0.12.1
 tornado==6.2
 tqdm==4.64.0


### PR DESCRIPTION
Fix the Docker build CUBLAS error :  pytorch1.13 automatically installs nvidia_cublas_cu11, nvidia_cuda_nvrtc_cu11, nvidia_cuda_runtime_cu11, and nvidia_cudnn_cu11. the existing build has its own CUDA toolKit already installed hence the
the library is breaking, the fix is to uninstall the pip version of nvidia_cublas_cu11.

Ref: https://stackoverflow.com/questions/74394695/how-does-one-fix-when-torch-cant-find-cuda-error-version-libcublaslt-so-11-no