### PR TITLE
Ubuntu 22.04 torch 131+cu117 upgrade

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -36,7 +36,7 @@ ARG VCS_URL="https://github.com/WildMeOrg/wildbook-ia"
 
 ARG VCS_REF="main"
 
-ARG BUILD_DATE="2020"
+ARG BUILD_DATE="2023"
 
 LABEL autoheal=true
 
@@ -101,8 +101,10 @@ RUN set -ex \
  && apt-get remove -y \
      python3-pyqt5* \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+     qtbase5-dev \
+     qtchooser \
      qt5-qmake \
-     qt5-default \
+     qtbase5-dev-tools \
  && /virtualenv/env3/bin/pip uninstall -y \
      pyqt5 \
  && /virtualenv/env3/bin/pip install --upgrade \

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
  && git pull \
  && cd /wbia/wildbook-ia/ \
  && git reset --hard origin/main \
+ && git config pull.rebase true \
  && git pull
 
 ##########################################################################################

--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG WBIA_UBUNTU_IMAGE=nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu20.04
+ARG WBIA_UBUNTU_IMAGE=nvidia/cuda:11.7.0-cudnn8-runtime-ubuntu22.04
 
 FROM ${WBIA_UBUNTU_IMAGE} as org.wildme.wbia.base
 

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -16,7 +16,7 @@ docker==6.0.0
 Flask-Caching==2.0.1
 Flask-CAS==1.0.2
 Flask-Cors==3.0.10
-Flask-Login==0.5.0
+Flask-Login==0.9.6
 # flask-marshmallow==0.7.0
 Flask-Minify==0.39
 Flask-OAuthlib==0.5.0
@@ -74,9 +74,9 @@ sqlalchemy==1.4.14
 SQLAlchemy-Utils==0.38.3
 tensorboard_logger==0.1.0
 Theano==1.0.5
-torch==1.12.1
-torchvision==0.13.1
-torchaudio==0.12.1
+torch==1.13.1
+torchvision==0.14.1
+torchaudio==0.13.1
 tornado==6.2
 tqdm==4.64.0
 ubelt==1.2.1

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -16,10 +16,10 @@ docker==6.0.0
 Flask-Caching==2.0.1
 Flask-CAS==1.0.2
 Flask-Cors==3.0.10
-Flask-Login==0.9.6
+Flask-Login==0.5.0
 # flask-marshmallow==0.7.0
 Flask-Minify==0.39
-Flask-OAuthlib==0.5.0
+Flask-OAuthlib==0.9.6
 Flask-Paranoid==0.3.0
 flask-restx==1.1.0
 # Flask-SQLAlchemy==2.5.0


### PR DESCRIPTION
Following Upgrade and Bug fixes included in this release.

Upgrade:
-------------------
Ubuntu 22.04 Docker 
Nvidia Cudnn 8 
Cuda driver 11.7 
Torch 1.13.1 

Fix:
-----------------
Upgrading Flask OAUthLib versions to fix the AttributeError: 'OAuth2Provider' object has no attribute 'invalid_response'