### PR TITLE
Adds gradcam toggle

### DIFF
--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -936,6 +936,7 @@ def query_chips_graph(
 
     proot = query_config_dict.get('pipeline_root', 'vsmany')
     proot = query_config_dict.get('proot', proot)
+    use_gradcam = query_config_dict.get('use_gradcam', False)
     logger.info('query_config_dict = {!r}'.format(query_config_dict))
 
     curvrank_daily_tag = query_config_dict.get('curvrank_daily_tag', None)
@@ -1077,7 +1078,7 @@ def query_chips_graph(
             daid_set = list(set(daid_set))
             logger.info('Visualizing %d annots: %r' % (len(daid_set), daid_set))
 
-            if proot.lower() == 'miewid':
+            if proot.lower() == 'miewid' and use_gradcam:
                 logger.info('Batch processing miewid match images')
                 batch_images = qreq_.render_batch_result(cm, daid_set)
 
@@ -1139,7 +1140,7 @@ def query_chips_graph(
 
             extern_flag_list = []
             for daid in daid_list_:
-                if proot.lower() == 'miewid':
+                if proot.lower() == 'miewid' and use_gradcam:
                     break
                 extern_flag = daid in daid_set
 


### PR DESCRIPTION
Intended to be used in conjunction with latest MiewID commit: https://github.com/WildMeOrg/wbia-plugin-miew-id/commit/7e2c4780b8d1f50182aaf125a2858843e9fc62b1 Docker build will automatically pull this.

Example API call:
`
... 
'query_config_dict': {
                'pipeline_root': MiewId,
                'use_gradcam': True,
            },
...
            `
            
If `use_gradcam` is not specified, the default value is `False`.

Shaves off ~20 seconds per query taken for calculating and rendering gradcam results.